### PR TITLE
buster has nodejs v10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openplotter-settings (2.6.3-stable) bionic; urgency=medium
+
+  * Remove force load of nodejs v10 if nodejs is installed v10, v12, v14
+
+ -- Sailoog <info@sailoog.com>  Thu, 28 Jan 2021 16:35:02 +0100
+
 openplotter-settings (2.6.2-stable) bionic; urgency=medium
 
   * Remove password request for sudoers

--- a/openplotterSettings/appsList.py
+++ b/openplotterSettings/appsList.py
@@ -232,7 +232,7 @@ class AppsList:
 		'package': 'openplotter-signalk-installer',
 		'preUninstall': platform2.admin+' signalkPreUninstall',
 		'uninstall': 'openplotter-signalk-installer',
-		'sources': ['http://ppa.launchpad.net/openplotter/openplotter/ubuntu','https://deb.nodesource.com/node_10.x'],
+		'sources': ['http://ppa.launchpad.net/openplotter/openplotter/ubuntu'],
 		'dev': 'no',
 		'entryPoint': 'openplotter-signalk-installer',
 		'postInstall': platform2.admin+' signalkPostInstall',

--- a/openplotterSettings/installSources.py
+++ b/openplotterSettings/installSources.py
@@ -94,12 +94,16 @@ def main():
 		elif RELEASE_DATA['ID'] == 'linuxmint': codename_node = codename_ubuntu
 		else: codename_node = codename_debian
 
-		deb = 'deb https://deb.nodesource.com/node_10.x '+codename_node+' main\ndeb-src https://deb.nodesource.com/node_10.x '+codename_node+' main'
-		if not 'https://deb.nodesource.com/node_10.x '+codename_node in sources:
-			if not deb in fileData: fileDataList.append(deb)
-			print(_('Added Node.js 10 packages source'))
-		else: 
-			print(_('Node.js 10 packages source already exists'))
+		nodejs = subprocess.check_output('node -v', shell=True).decode(sys.stdin.encoding)
+		if nodejs[0:3] in ['v10','v12','v14']:
+			pass
+		else:
+			deb = 'deb https://deb.nodesource.com/node_10.x '+codename_node+' main\ndeb-src https://deb.nodesource.com/node_10.x '+codename_node+' main'
+			if not 'https://deb.nodesource.com/node_10.x '+codename_node in sources:
+				if not deb in fileData: fileDataList.append(deb)
+				print(_('Added Node.js 10 packages source'))
+			else: 
+				print(_('Node.js 10 packages source already exists'))
 
 		removeList = []
 		removeList.append('deb https://www.free-x.de/debian buster main contrib non-free')

--- a/openplotterSettings/version.py
+++ b/openplotterSettings/version.py
@@ -1,3 +1,3 @@
-version = '2.6.2'
+version = '2.6.3'
 codeName = 'Open Arms'
 state = 'stable'


### PR DESCRIPTION
Openplotter forces everyone to install nodejs v10 from nodejs repository. 
Raspbian buster comes with a working nodejs v10. 
Installing SignalK isn't an issue anymore. In the past with v8 it was an issue.
When working with Ubuntu 20.xx nodejs is v12. 
Why should we force anybody to downgrade to old v10?
