### PR TITLE
Query effective $HOME path from OS

### DIFF
--- a/openplotterSettings/conf.py
+++ b/openplotterSettings/conf.py
@@ -27,7 +27,7 @@ class Conf:
 			except:
 				import pwd
 				self.user = pwd.getpwuid(int(os.environ["PKEXEC_UID"])).pw_name
-		self.home = '/home/'+self.user
+		self.home = os.path.expanduser('~'+self.user)
 
 		self.data_conf = configparser.ConfigParser()
 


### PR DESCRIPTION
Query the Operating system for the actual $HOME location it use for the provided user is more reliable than assuming it's in /home/.      /home/ is just a convention.  root don't use it. Sometime, database, webservers, ftp or massively shared instances legitimately have different locations paths. 